### PR TITLE
Fix incorrect URL editor assignment

### DIFF
--- a/rider/src/main/kotlin/com/jetbrains/aspire/rider/run/file/AspireFileConfigurationViewModel.kt
+++ b/rider/src/main/kotlin/com/jetbrains/aspire/rider/run/file/AspireFileConfigurationViewModel.kt
@@ -272,6 +272,7 @@ internal class AspireFileConfigurationViewModel(
             val effectiveLaunchBrowser =
                 if (trackBrowserLaunch) getLaunchBrowserFlag(selectedProfile?.content)
                 else dotNetStartBrowserParameters.startAfterLaunch
+
             val browserSettings = BrowserSettings(
                 effectiveLaunchBrowser,
                 dotNetStartBrowserParameters.withJavaScriptDebugger,
@@ -279,7 +280,6 @@ internal class AspireFileConfigurationViewModel(
             )
             dotNetBrowserSettingsEditor.settings.set(browserSettings)
             usePodmanRuntimeFlagEditor.isSelected.set(usePodmanRuntime)
-            urlEditor.text.set(dotNetStartBrowserParameters.url)
             isLoaded = true
         }
     }


### PR DESCRIPTION
After the merge of #584, we have a wrong behavior of the URL editor in the Aspire Single-File AppHost run configuration's editor.

The commit within this pull request addresses that issue where the URL editor was assigned incorrectly.