### PR TITLE
Start Aspire debug session for Microsoft.Testing.Platform test runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - Update platform version to 2026.2-RC1-SNAPSHOT
 
+### Fixed
+
+- Debug session was not started for tests executed with Microsoft.Testing.Platform (MSTest runner, xUnit v3, TUnit), so breakpoints in Aspire resource projects were not hit when debugging such tests
+
 ## [2.7.4] - 2026-06-17
 
 ### Fixed

--- a/src/dotnet/AspirePlugin/UnitTest/AspireUnitTestHostControllerExtension.cs
+++ b/src/dotnet/AspirePlugin/UnitTest/AspireUnitTestHostControllerExtension.cs
@@ -9,7 +9,6 @@ using JetBrains.Rd.Tasks;
 using JetBrains.ReSharper.Feature.Services.Protocol;
 using JetBrains.ReSharper.UnitTestFramework.Execution.Hosting;
 using JetBrains.ReSharper.UnitTestFramework.Execution.Launch;
-using JetBrains.ReSharper.UnitTestFramework.Execution.TestRunner;
 using JetBrains.Rider.Aspire.Plugin.Generated;
 using JetBrains.Util.Dotnet.TargetFrameworkIds;
 
@@ -24,7 +23,8 @@ public class AspireUnitTestHostControllerExtension(ISolution solution) : ITaskRu
 
     public bool IsApplicable(IUnitTestRun run)
     {
-        if (run.RuntimeDescriptor is not TestRunnerRuntimeDescriptor.NetCore netDescriptor) return false;
+        if (run.RuntimeDescriptor is not IRuntimeDescriptorWithTargetFramework netDescriptor) return false;
+        if (!netDescriptor.TargetFrameworkId.IsNetCoreApp) return false;
 
         var project = netDescriptor.Project;
 
@@ -47,7 +47,8 @@ public class AspireUnitTestHostControllerExtension(ISolution solution) : ITaskRu
 
     public async Task PrepareForRun(IUnitTestRun run, ITaskRunnerHostController next)
     {
-        if (run.RuntimeDescriptor is TestRunnerRuntimeDescriptor.NetCore netDescriptor)
+        if (run.RuntimeDescriptor is IRuntimeDescriptorWithTargetFramework netDescriptor &&
+            netDescriptor.TargetFrameworkId.IsNetCoreApp)
         {
             var project = netDescriptor.Project;
             var aspireHostProject = GetAspireHostProject(project, netDescriptor.TargetFrameworkId);


### PR DESCRIPTION
# Start Aspire debug session for Microsoft.Testing.Platform test runs

## Problem

Debugging Aspire integration tests works for the classic VSTest-based runners (xUnit v2, NUnit, MSTest via VSTest), but **not** for test frameworks running on **Microsoft.Testing.Platform** (MSTest runner, xUnit v3, TUnit): breakpoints inside Aspire resource projects are never hit. The test process itself debugs fine; the resources orchestrated by DCP are started as plain processes with no debugger attached.

Originally implemented in #216 (closes the gap left for #185).

## Root cause

`AspireUnitTestHostControllerExtension.IsApplicable` pattern-matches the run's descriptor against `TestRunnerRuntimeDescriptor.NetCore`:

```csharp
if (run.RuntimeDescriptor is not TestRunnerRuntimeDescriptor.NetCore netDescriptor) return false;
```

Runs executed through Microsoft.Testing.Platform use a different strategy (`TestingPlatformRunStrategy`), whose `GetRuntimeDescriptor` returns a `TestingPlatformRuntimeDescriptor.NetCore` — a separate class from `JetBrains.ReSharper.UnitTesting.VsTest.Provider`. The type test fails, `IsApplicable` returns `false`, the extension never wraps the host controller, no `StartAspireHostRequest` is sent, and the `DEBUG_SESSION_*` environment variables are never injected. DCP inside the test process then launches resources itself, undebugged.

The rest of the pipeline already supports this scenario:

- `UnitTestRun.StartCore` calls `HostController.PrepareForRun` for every run regardless of run strategy, so the extension chain does execute for Microsoft.Testing.Platform runs once `IsApplicable` passes.
- `TestingPlatformClientProvider.PrepareStartInfo` applies `TestRunner.EnvironmentVariables` to the spawned test-host process, so the injected debug-session variables reach DCP.

## Fix

Match `IRuntimeDescriptorWithTargetFramework` (implemented by both `TestRunnerRuntimeDescriptor` and `TestingPlatformRuntimeDescriptor`) and gate on `TargetFrameworkId.IsNetCoreApp`, which preserves the previous "NetCore only" behavior without taking a dependency on the `JetBrains.ReSharper.UnitTesting.VsTest.Provider` assembly. The `Aspire.Hosting.Testing` package reference and AppHost project-reference checks are unchanged and keep the extension scoped to real Aspire test projects.

## Testing

- The `AspirePlugin` project compiles cleanly against the 2026.2 EAP8 SDK (`riderVersion` from `gradle.properties`).
- I have not been able to run a full sandboxed-IDE end-to-end verification of this change; validation inside a debug session with a Microsoft.Testing.Platform framework (e.g. TUnit + `DistributedApplicationTestingBuilder`) would be appreciated. Happy to iterate if the team prefers an explicit two-type match over the interface match.

Context: I maintain [TUnit](https://github.com/thomhurst/TUnit) (Microsoft.Testing.Platform-based) and its `TUnit.Aspire` integration, where users cannot currently debug Aspire resources from tests in Rider.
