### PR TITLE
Add a setting to disable building of external .NET projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,21 @@
 
 ## [Unreleased]
 
-### Changed
+### Added
 
-- Update platform version to 2026.2-RC1-SNAPSHOT
+- Support file-based projects for the session launch
+- [#704](https://github.com/JetBrains/aspire-plugin/issues/704) Setting to disable building of external .NET projects
 
 ### Fixed
 
+- Run gutter marks behavior for apphost host configuration
 - Debug session was not started for tests executed with Microsoft.Testing.Platform (MSTest runner, xUnit v3, TUnit), so breakpoints in Aspire resource projects were not hit when debugging such tests
+
+## [2.7.5] - 2026-07-16
+
+### Changed
+
+- Update platform version to 2026.2-RC1-SNAPSHOT
 
 ## [2.7.4] - 2026-06-17
 
@@ -714,7 +722,8 @@
 
 - Support for running and debugging of Aspire projects
 
-[Unreleased]: https://github.com/JetBrains/aspire-plugin/compare/2.7.4...HEAD
+[Unreleased]: https://github.com/JetBrains/aspire-plugin/compare/2.7.5...HEAD
+[2.7.5]: https://github.com/JetBrains/aspire-plugin/compare/2.7.4...2.7.5
 [2.7.4]: https://github.com/JetBrains/aspire-plugin/compare/2.7.3...2.7.4
 [2.7.3]: https://github.com/JetBrains/aspire-plugin/compare/2.7.2...2.7.3
 [2.7.2]: https://github.com/JetBrains/aspire-plugin/compare/2.7.1...2.7.2

--- a/core/src/main/kotlin/com/jetbrains/aspire/settings/AspireConfigurable.kt
+++ b/core/src/main/kotlin/com/jetbrains/aspire/settings/AspireConfigurable.kt
@@ -19,6 +19,10 @@ internal class AspireConfigurable : BoundConfigurable(AspireCoreBundle.message("
                 .bindSelected(settings::forceBuildOfAppHostReferencedProjects)
         }
         row {
+            checkBox(AspireCoreBundle.message("configurable.Aspire.build.external.net.projects"))
+                .bindSelected(settings::buildExternalNetProjects)
+        }
+        row {
             checkBox(AspireCoreBundle.message("configurable.Aspire.do.not.launch.browser"))
                 .bindSelected(settings::doNotLaunchBrowserForProjects)
         }

--- a/core/src/main/kotlin/com/jetbrains/aspire/settings/AspireSettings.kt
+++ b/core/src/main/kotlin/com/jetbrains/aspire/settings/AspireSettings.kt
@@ -18,6 +18,12 @@ class AspireSettings : SimplePersistentStateComponent<AspireSettingsState>(Aspir
             state.forceBuildOfAppHostReferencedProjects = value
         }
 
+    var buildExternalNetProjects
+        get() = state.buildExternalNetProjects
+        set(value) {
+            state.buildExternalNetProjects = value
+        }
+
     var doNotLaunchBrowserForProjects
         get() = state.doNotLaunchBrowserForProjects
         set(value) {

--- a/core/src/main/kotlin/com/jetbrains/aspire/settings/AspireSettingsState.kt
+++ b/core/src/main/kotlin/com/jetbrains/aspire/settings/AspireSettingsState.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.components.BaseState
 
 class AspireSettingsState : BaseState() {
     var forceBuildOfAppHostReferencedProjects by property(false)
+    var buildExternalNetProjects by property(true)
     var doNotLaunchBrowserForProjects by property(true)
     var connectToDcpViaHttps by property(true)
     var connectToDatabase by property(true)

--- a/core/src/main/resources/messages/AspireCoreBundle.properties
+++ b/core/src/main/resources/messages/AspireCoreBundle.properties
@@ -53,6 +53,7 @@ run.editor.url=URL
 
 configurable.Aspire=Aspire
 configurable.Aspire.force.build.of.apphost.referenced.projects=Force build of projects referenced by AppHost
+configurable.Aspire.build.external.net.projects=Build external .NET projects before execution
 configurable.Aspire.do.not.launch.browser=Do not launch the browser for child projects
 configurable.Aspire.connect.to.dcp.via.https=Connect to DCP via HTTPS
 configurable.Aspire.databases=Database Connection

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = me.rafaelldi.aspire
-version = 2.7.5
+version = 2.8.0
 
 pluginRepositoryUrl = https://github.com/JetBrains/aspire-plugin
 
@@ -9,11 +9,11 @@ pluginRepositoryUrl = https://github.com/JetBrains/aspire-plugin
 #   EAP:      2020.3-EAP2-SNAPSHOT
 #   Nightly:  2020.3-SNAPSHOT
 ideaVersion = 2026.2
-riderVersion = 2026.2
+riderVersion = 2026.2.0.1
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerificationIdeVersion = 2026.2
+pluginVerificationIdeVersion = 2026.2.0.1
 
 dotnetBuildConfiguration = Release
 

--- a/rider/src/main/kotlin/com/jetbrains/aspire/rider/sessions/DotNetStartSessionRequestHandler.kt
+++ b/rider/src/main/kotlin/com/jetbrains/aspire/rider/sessions/DotNetStartSessionRequestHandler.kt
@@ -137,6 +137,13 @@ internal class DotNetStartSessionRequestHandler : StartSessionRequestHandler {
 
     private suspend fun buildExternalProjects(projectPaths: List<Path>, project: Project) {
         if (projectPaths.isEmpty()) return
+
+        val settings = AspireSettings.getInstance()
+        if (!settings.buildExternalNetProjects) {
+            LOG.trace("Skip building external .NET projects")
+            return
+        }
+
         LOG.trace { "Building ${projectPaths.size} external project(s): ${projectPaths.map { it.fileName }}" }
         val buildService = DotNetBuildService.getInstance(project)
         buildService.buildProjects(projectPaths)


### PR DESCRIPTION
Fixes #704 